### PR TITLE
FIX: Allows objects to remain in their same relative positions on the map during world wraps

### DIFF
--- a/WorldWrap/Assets/Scenes/SampleScene.unity
+++ b/WorldWrap/Assets/Scenes/SampleScene.unity
@@ -130,11 +130,36 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 505769308193590981, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e3b5d079524b14d0b9bc973f8bab3964, type: 2}
+    - target: {fileID: 1883837749812722480, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248648862971507711, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2254315790140907470, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2474585676692234037, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2553714956594502638, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -145,16 +170,31 @@ PrefabInstance:
       propertyPath: m_Name
       value: GrayBlock
       objectReference: {fileID: 0}
+    - target: {fileID: 2577308036908700981, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2746300833372258064, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e3b5d079524b14d0b9bc973f8bab3964, type: 2}
+    - target: {fileID: 2826908958561369035, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3607934931553181804, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e3b5d079524b14d0b9bc973f8bab3964, type: 2}
+    - target: {fileID: 4085777820194923791, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
@@ -210,11 +250,31 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4458516833351926257, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629524875331301120, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4932792727931014949, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e3b5d079524b14d0b9bc973f8bab3964, type: 2}
+    - target: {fileID: 5203277866649682258, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468763228395834650, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 5798924806565204057, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -225,6 +285,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e3b5d079524b14d0b9bc973f8bab3964, type: 2}
+    - target: {fileID: 6546975539525391674, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 6580073148127144334, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -235,11 +300,26 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e3b5d079524b14d0b9bc973f8bab3964, type: 2}
+    - target: {fileID: 8056562210375924627, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8170061802116915596, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e3b5d079524b14d0b9bc973f8bab3964, type: 2}
+    - target: {fileID: 8442647782206669225, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016468769183199227, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8825810ddf0f5419aac6ea7be02043f4, type: 3}
 --- !u!1 &33976001 stripped
@@ -624,11 +704,36 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 505769308193590981, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 7269d532c1fc144c88545f41748c7469, type: 2}
+    - target: {fileID: 1883837749812722480, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248648862971507711, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2254315790140907470, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2474585676692234037, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2553714956594502638, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -639,16 +744,31 @@ PrefabInstance:
       propertyPath: m_Name
       value: WhiteBlock
       objectReference: {fileID: 0}
+    - target: {fileID: 2577308036908700981, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2746300833372258064, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 7269d532c1fc144c88545f41748c7469, type: 2}
+    - target: {fileID: 2826908958561369035, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3607934931553181804, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 7269d532c1fc144c88545f41748c7469, type: 2}
+    - target: {fileID: 4085777820194923791, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
@@ -704,11 +824,31 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4458516833351926257, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629524875331301120, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4932792727931014949, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 7269d532c1fc144c88545f41748c7469, type: 2}
+    - target: {fileID: 5203277866649682258, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468763228395834650, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 5798924806565204057, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -719,6 +859,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 7269d532c1fc144c88545f41748c7469, type: 2}
+    - target: {fileID: 6546975539525391674, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 6580073148127144334, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -729,11 +874,26 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 7269d532c1fc144c88545f41748c7469, type: 2}
+    - target: {fileID: 8056562210375924627, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8170061802116915596, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 7269d532c1fc144c88545f41748c7469, type: 2}
+    - target: {fileID: 8442647782206669225, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016468769183199227, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8825810ddf0f5419aac6ea7be02043f4, type: 3}
 --- !u!1 &118404502
@@ -1972,6 +2132,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Ball (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 2863848475787073640, guid: ceba5eb1d50934849bcaafc8bdb93daa,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2863848475787073641, guid: ceba5eb1d50934849bcaafc8bdb93daa,
         type: 3}
       propertyPath: m_RootOrder
@@ -2453,11 +2618,36 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 505769308193590981, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: b5848cce5cf15446b831a8d8a81f38ca, type: 2}
+    - target: {fileID: 1883837749812722480, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248648862971507711, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2254315790140907470, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2474585676692234037, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2553714956594502638, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -2468,16 +2658,31 @@ PrefabInstance:
       propertyPath: m_Name
       value: YellowBlock
       objectReference: {fileID: 0}
+    - target: {fileID: 2577308036908700981, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2746300833372258064, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: b5848cce5cf15446b831a8d8a81f38ca, type: 2}
+    - target: {fileID: 2826908958561369035, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3607934931553181804, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: b5848cce5cf15446b831a8d8a81f38ca, type: 2}
+    - target: {fileID: 4085777820194923791, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
@@ -2533,11 +2738,31 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4458516833351926257, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629524875331301120, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4932792727931014949, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: b5848cce5cf15446b831a8d8a81f38ca, type: 2}
+    - target: {fileID: 5203277866649682258, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468763228395834650, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 5798924806565204057, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -2548,6 +2773,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: b5848cce5cf15446b831a8d8a81f38ca, type: 2}
+    - target: {fileID: 6546975539525391674, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 6580073148127144334, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -2558,11 +2788,26 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: b5848cce5cf15446b831a8d8a81f38ca, type: 2}
+    - target: {fileID: 8056562210375924627, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8170061802116915596, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: b5848cce5cf15446b831a8d8a81f38ca, type: 2}
+    - target: {fileID: 8442647782206669225, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016468769183199227, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8825810ddf0f5419aac6ea7be02043f4, type: 3}
 --- !u!1 &524996673
@@ -2609,6 +2854,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Ball (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2863848475787073640, guid: ceba5eb1d50934849bcaafc8bdb93daa,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2863848475787073641, guid: ceba5eb1d50934849bcaafc8bdb93daa,
         type: 3}
@@ -2711,11 +2961,36 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 505769308193590981, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 917987649d2734bbdbc7efc7b9bc4629, type: 2}
+    - target: {fileID: 1883837749812722480, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248648862971507711, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2254315790140907470, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2474585676692234037, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2553714956594502638, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -2726,16 +3001,31 @@ PrefabInstance:
       propertyPath: m_Name
       value: OrangeBlock
       objectReference: {fileID: 0}
+    - target: {fileID: 2577308036908700981, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2746300833372258064, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 917987649d2734bbdbc7efc7b9bc4629, type: 2}
+    - target: {fileID: 2826908958561369035, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3607934931553181804, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 917987649d2734bbdbc7efc7b9bc4629, type: 2}
+    - target: {fileID: 4085777820194923791, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
@@ -2791,11 +3081,31 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4458516833351926257, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629524875331301120, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4932792727931014949, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 917987649d2734bbdbc7efc7b9bc4629, type: 2}
+    - target: {fileID: 5203277866649682258, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468763228395834650, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 5798924806565204057, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -2806,6 +3116,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 917987649d2734bbdbc7efc7b9bc4629, type: 2}
+    - target: {fileID: 6546975539525391674, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 6580073148127144334, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -2816,11 +3131,26 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 917987649d2734bbdbc7efc7b9bc4629, type: 2}
+    - target: {fileID: 8056562210375924627, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8170061802116915596, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 917987649d2734bbdbc7efc7b9bc4629, type: 2}
+    - target: {fileID: 8442647782206669225, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016468769183199227, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8825810ddf0f5419aac6ea7be02043f4, type: 3}
 --- !u!1 &654252470
@@ -3076,7 +3406,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 699699324}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Shelf
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3440,11 +3770,36 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 505769308193590981, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e24a763c89473462480cb7db4a510a26, type: 2}
+    - target: {fileID: 1883837749812722480, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248648862971507711, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2254315790140907470, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2474585676692234037, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2553714956594502638, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -3455,16 +3810,31 @@ PrefabInstance:
       propertyPath: m_Name
       value: GreenBlock
       objectReference: {fileID: 0}
+    - target: {fileID: 2577308036908700981, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2746300833372258064, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e24a763c89473462480cb7db4a510a26, type: 2}
+    - target: {fileID: 2826908958561369035, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3607934931553181804, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e24a763c89473462480cb7db4a510a26, type: 2}
+    - target: {fileID: 4085777820194923791, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
@@ -3520,11 +3890,31 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4458516833351926257, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629524875331301120, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4932792727931014949, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e24a763c89473462480cb7db4a510a26, type: 2}
+    - target: {fileID: 5203277866649682258, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468763228395834650, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 5798924806565204057, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -3535,6 +3925,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e24a763c89473462480cb7db4a510a26, type: 2}
+    - target: {fileID: 6546975539525391674, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 6580073148127144334, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -3545,11 +3940,26 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e24a763c89473462480cb7db4a510a26, type: 2}
+    - target: {fileID: 8056562210375924627, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8170061802116915596, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e24a763c89473462480cb7db4a510a26, type: 2}
+    - target: {fileID: 8442647782206669225, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016468769183199227, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8825810ddf0f5419aac6ea7be02043f4, type: 3}
 --- !u!1 &820851463
@@ -3718,11 +4128,36 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 505769308193590981, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 80bab87f3d69a4561aa4beb0465f5f5e, type: 2}
+    - target: {fileID: 1883837749812722480, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248648862971507711, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2254315790140907470, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2474585676692234037, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2553714956594502638, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -3733,16 +4168,31 @@ PrefabInstance:
       propertyPath: m_Name
       value: PurpleBlock
       objectReference: {fileID: 0}
+    - target: {fileID: 2577308036908700981, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2746300833372258064, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 80bab87f3d69a4561aa4beb0465f5f5e, type: 2}
+    - target: {fileID: 2826908958561369035, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3607934931553181804, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 80bab87f3d69a4561aa4beb0465f5f5e, type: 2}
+    - target: {fileID: 4085777820194923791, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
@@ -3798,11 +4248,31 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4458516833351926257, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629524875331301120, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4932792727931014949, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 80bab87f3d69a4561aa4beb0465f5f5e, type: 2}
+    - target: {fileID: 5203277866649682258, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468763228395834650, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 5798924806565204057, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -3813,6 +4283,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 80bab87f3d69a4561aa4beb0465f5f5e, type: 2}
+    - target: {fileID: 6546975539525391674, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 6580073148127144334, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -3823,11 +4298,26 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 80bab87f3d69a4561aa4beb0465f5f5e, type: 2}
+    - target: {fileID: 8056562210375924627, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8170061802116915596, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 80bab87f3d69a4561aa4beb0465f5f5e, type: 2}
+    - target: {fileID: 8442647782206669225, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016468769183199227, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8825810ddf0f5419aac6ea7be02043f4, type: 3}
 --- !u!1 &937172303
@@ -3947,11 +4437,36 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 505769308193590981, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 4175318bc65224b778b93d0274da8b7b, type: 2}
+    - target: {fileID: 1883837749812722480, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248648862971507711, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2254315790140907470, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2474585676692234037, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2553714956594502638, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -3962,16 +4477,31 @@ PrefabInstance:
       propertyPath: m_Name
       value: CyanBlock
       objectReference: {fileID: 0}
+    - target: {fileID: 2577308036908700981, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2746300833372258064, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 4175318bc65224b778b93d0274da8b7b, type: 2}
+    - target: {fileID: 2826908958561369035, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3607934931553181804, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 4175318bc65224b778b93d0274da8b7b, type: 2}
+    - target: {fileID: 4085777820194923791, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
@@ -4027,11 +4557,31 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4458516833351926257, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629524875331301120, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4932792727931014949, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 4175318bc65224b778b93d0274da8b7b, type: 2}
+    - target: {fileID: 5203277866649682258, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468763228395834650, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 5798924806565204057, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -4042,6 +4592,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 4175318bc65224b778b93d0274da8b7b, type: 2}
+    - target: {fileID: 6546975539525391674, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 6580073148127144334, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -4052,11 +4607,26 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 4175318bc65224b778b93d0274da8b7b, type: 2}
+    - target: {fileID: 8056562210375924627, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8170061802116915596, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 4175318bc65224b778b93d0274da8b7b, type: 2}
+    - target: {fileID: 8442647782206669225, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016468769183199227, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8825810ddf0f5419aac6ea7be02043f4, type: 3}
 --- !u!1 &970519668
@@ -5061,7 +5631,7 @@ GameObject:
   - component: {fileID: 1194060495}
   - component: {fileID: 1194060494}
   - component: {fileID: 1194060493}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: ShelfObject
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5412,7 +5982,7 @@ MonoBehaviour:
   - {fileID: 1224477082}
   - {fileID: 1769589972}
   player: {fileID: 691913570}
-  wrapLayer: 5
+  wrapLayer: 6
 --- !u!4 &1244485131
 Transform:
   m_ObjectHideFlags: 0
@@ -5798,11 +6368,36 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 505769308193590981, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 42a94cbdbade148d9a60d18c8ab48c1d, type: 2}
+    - target: {fileID: 1883837749812722480, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248648862971507711, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2254315790140907470, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2474585676692234037, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2553714956594502638, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -5813,16 +6408,31 @@ PrefabInstance:
       propertyPath: m_Name
       value: BlueBlock
       objectReference: {fileID: 0}
+    - target: {fileID: 2577308036908700981, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2746300833372258064, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 42a94cbdbade148d9a60d18c8ab48c1d, type: 2}
+    - target: {fileID: 2826908958561369035, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3607934931553181804, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 42a94cbdbade148d9a60d18c8ab48c1d, type: 2}
+    - target: {fileID: 4085777820194923791, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
@@ -5878,11 +6488,31 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4458516833351926257, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629524875331301120, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4932792727931014949, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 42a94cbdbade148d9a60d18c8ab48c1d, type: 2}
+    - target: {fileID: 5203277866649682258, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468763228395834650, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 5798924806565204057, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -5893,6 +6523,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 42a94cbdbade148d9a60d18c8ab48c1d, type: 2}
+    - target: {fileID: 6546975539525391674, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 6580073148127144334, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -5903,11 +6538,26 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 42a94cbdbade148d9a60d18c8ab48c1d, type: 2}
+    - target: {fileID: 8056562210375924627, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8170061802116915596, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 42a94cbdbade148d9a60d18c8ab48c1d, type: 2}
+    - target: {fileID: 8442647782206669225, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016468769183199227, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8825810ddf0f5419aac6ea7be02043f4, type: 3}
 --- !u!1 &1351721545
@@ -7161,6 +7811,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Ball (3)
       objectReference: {fileID: 0}
+    - target: {fileID: 2863848475787073640, guid: ceba5eb1d50934849bcaafc8bdb93daa,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2863848475787073641, guid: ceba5eb1d50934849bcaafc8bdb93daa,
         type: 3}
       propertyPath: m_RootOrder
@@ -8171,6 +8826,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Ball
       objectReference: {fileID: 0}
+    - target: {fileID: 2863848475787073640, guid: ceba5eb1d50934849bcaafc8bdb93daa,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2863848475787073641, guid: ceba5eb1d50934849bcaafc8bdb93daa,
         type: 3}
       propertyPath: m_RootOrder
@@ -8250,12 +8910,47 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1883837749812722480, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248648862971507711, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2254315790140907470, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2474585676692234037, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2577308036908700981, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Name
       value: RedBlock
       objectReference: {fileID: 0}
     - target: {fileID: 2577308036908700981, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2826908958561369035, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4085777820194923791, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_Layer
       value: 6
@@ -8314,6 +9009,46 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4458516833351926257, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629524875331301120, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5203277866649682258, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468763228395834650, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6546975539525391674, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8056562210375924627, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8442647782206669225, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016468769183199227, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8825810ddf0f5419aac6ea7be02043f4, type: 3}

--- a/WorldWrap/Assets/Scenes/SampleScene.unity
+++ b/WorldWrap/Assets/Scenes/SampleScene.unity
@@ -128,7 +128,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 71671166}
     m_Modifications:
     - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -198,22 +198,37 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.01111111
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 30
+      value: 0.3333333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: -0.4833333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -30
+      value: -0.3333333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -223,17 +238,17 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -325,6 +340,12 @@ PrefabInstance:
 --- !u!1 &33976001 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2577308036908700981, guid: 8825810ddf0f5419aac6ea7be02043f4,
+    type: 3}
+  m_PrefabInstance: {fileID: 1316661912}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &33976002 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
     type: 3}
   m_PrefabInstance: {fileID: 1316661912}
   m_PrefabAsset: {fileID: 0}
@@ -444,6 +465,12 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 839422417}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &53599419 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+    type: 3}
+  m_PrefabInstance: {fileID: 839422417}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &64921084
 GameObject:
   m_ObjectHideFlags: 0
@@ -477,6 +504,125 @@ Transform:
   m_Father: {fileID: 1017071410}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &71671165
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 71671166}
+  - component: {fileID: 71671169}
+  - component: {fileID: 71671168}
+  - component: {fileID: 71671167}
+  - component: {fileID: 71671170}
+  m_Layer: 0
+  m_Name: GlobalBounds
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &71671166
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71671165}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 45, z: 0}
+  m_LocalScale: {x: 90, y: 90, z: 90}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1969571589}
+  - {fileID: 53599419}
+  - {fileID: 183356046}
+  - {fileID: 1539677945}
+  - {fileID: 33976002}
+  - {fileID: 361865333}
+  - {fileID: 1863711053}
+  - {fileID: 1224477083}
+  - {fileID: 1769589973}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &71671167
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71671165}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &71671168
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71671165}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: ee02f671debcc48dab7c4512d713317e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &71671169
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71671165}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &71671170
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71671165}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 649b90a10a146468bbf5e8d90c736e74, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &91103850
 GameObject:
   m_ObjectHideFlags: 0
@@ -702,7 +848,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 71671166}
     m_Modifications:
     - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -772,22 +918,37 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.01111111
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 30
+      value: 0.3333333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: -0.4833333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 30
+      value: 0.3333333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -797,17 +958,17 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -1009,6 +1170,12 @@ MeshFilter:
 --- !u!1 &183356045 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2577308036908700981, guid: 8825810ddf0f5419aac6ea7be02043f4,
+    type: 3}
+  m_PrefabInstance: {fileID: 624852658}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &183356046 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
     type: 3}
   m_PrefabInstance: {fileID: 624852658}
   m_PrefabAsset: {fileID: 0}
@@ -1752,6 +1919,12 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 510732830}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &361865333 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+    type: 3}
+  m_PrefabInstance: {fileID: 510732830}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &369934227
 GameObject:
   m_ObjectHideFlags: 0
@@ -2165,7 +2338,7 @@ PrefabInstance:
     - target: {fileID: 2863848475787073641, guid: ceba5eb1d50934849bcaafc8bdb93daa,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.5495814
+      value: 0.722
       objectReference: {fileID: 0}
     - target: {fileID: 2863848475787073641, guid: ceba5eb1d50934849bcaafc8bdb93daa,
         type: 3}
@@ -2616,7 +2789,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 71671166}
     m_Modifications:
     - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -2686,22 +2859,37 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.01111111
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -30
+      value: -0.3333333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: -0.4833333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -30
+      value: -0.3333333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -2711,17 +2899,17 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -2888,7 +3076,7 @@ PrefabInstance:
     - target: {fileID: 2863848475787073641, guid: ceba5eb1d50934849bcaafc8bdb93daa,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.5495814
+      value: 0.722
       objectReference: {fileID: 0}
     - target: {fileID: 2863848475787073641, guid: ceba5eb1d50934849bcaafc8bdb93daa,
         type: 3}
@@ -2959,7 +3147,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 71671166}
     m_Modifications:
     - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -3029,22 +3217,37 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.01111111
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -30
+      value: -0.3333333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: -0.4833333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 30
+      value: 0.3333333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -3054,17 +3257,17 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -3653,6 +3856,134 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 735345958}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &764793046
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 764793052}
+  - component: {fileID: 764793051}
+  - component: {fileID: 764793050}
+  - component: {fileID: 764793049}
+  - component: {fileID: 764793048}
+  - component: {fileID: 764793047}
+  m_Layer: 0
+  m_Name: Duck (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!54 &764793047
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 764793046}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 4
+  m_CollisionDetection: 0
+--- !u!114 &764793048
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 764793046}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9f5f8ffe9a6845b5b5247ffbe35b63f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 30
+--- !u!65 &764793049
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 764793046}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &764793050
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 764793046}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &764793051
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 764793046}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &764793052
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 764793046}
+  m_LocalRotation: {x: 0, y: 0.38268343, z: 0, w: 0.92387956}
+  m_LocalPosition: {x: -12.7502, y: 6.0995817, z: 6.5018544}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 45, z: 0}
 --- !u!1 &765034754
 GameObject:
   m_ObjectHideFlags: 0
@@ -3768,7 +4099,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 71671166}
     m_Modifications:
     - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -3838,17 +4169,32 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.01111111
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -30
+      value: -0.3333333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: -0.4833333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -3863,17 +4209,17 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -4126,7 +4472,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 71671166}
     m_Modifications:
     - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -4196,7 +4542,22 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.01111111
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -4206,12 +4567,12 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: -0.4833333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 30
+      value: 0.3333333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -4221,17 +4582,17 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -4435,7 +4796,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 71671166}
     m_Modifications:
     - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -4505,17 +4866,32 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.01111111
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 30
+      value: 0.3333333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: -0.4833333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -4530,17 +4906,17 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -4968,7 +5344,7 @@ Transform:
   - {fileID: 1860861124}
   - {fileID: 1424712083}
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1030520143
 GameObject:
@@ -5146,6 +5522,134 @@ Transform:
   m_Father: {fileID: 1017071410}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!1 &1084014513
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1084014519}
+  - component: {fileID: 1084014518}
+  - component: {fileID: 1084014517}
+  - component: {fileID: 1084014516}
+  - component: {fileID: 1084014515}
+  - component: {fileID: 1084014514}
+  m_Layer: 0
+  m_Name: Duck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!54 &1084014514
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1084014513}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 4
+  m_CollisionDetection: 0
+--- !u!114 &1084014515
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1084014513}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9f5f8ffe9a6845b5b5247ffbe35b63f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 30
+--- !u!65 &1084014516
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1084014513}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1084014517
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1084014513}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1084014518
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1084014513}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1084014519
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1084014513}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -12.7502, y: 7.3495817, z: 6.5018544}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1087276450
 GameObject:
   m_ObjectHideFlags: 0
@@ -5942,6 +6446,12 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 942564464}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &1224477083 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+    type: 3}
+  m_PrefabInstance: {fileID: 942564464}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1244485129
 GameObject:
   m_ObjectHideFlags: 0
@@ -5991,12 +6501,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1244485129}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.7479012, y: 0.41796872, z: -14.046626}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 13
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1245591339
 GameObject:
@@ -6366,7 +6876,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 71671166}
     m_Modifications:
     - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -6436,7 +6946,22 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.01111111
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -6446,12 +6971,12 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: -0.4833333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -30
+      value: -0.3333333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -6461,17 +6986,17 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -6885,6 +7410,12 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 96230083}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &1539677945 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+    type: 3}
+  m_PrefabInstance: {fileID: 96230083}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1561045580
 GameObject:
   m_ObjectHideFlags: 0
@@ -7281,6 +7812,134 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1635940221}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1642922707
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1642922713}
+  - component: {fileID: 1642922712}
+  - component: {fileID: 1642922711}
+  - component: {fileID: 1642922710}
+  - component: {fileID: 1642922709}
+  - component: {fileID: 1642922708}
+  m_Layer: 0
+  m_Name: Duck (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!54 &1642922708
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642922707}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 4
+  m_CollisionDetection: 0
+--- !u!114 &1642922709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642922707}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9f5f8ffe9a6845b5b5247ffbe35b63f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 30
+--- !u!65 &1642922710
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642922707}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1642922711
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642922707}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1642922712
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642922707}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1642922713
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642922707}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: -12.7502, y: 4.8495817, z: 6.5018544}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1 &1683494123
 GameObject:
   m_ObjectHideFlags: 0
@@ -7650,6 +8309,12 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 773834880}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &1769589973 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+    type: 3}
+  m_PrefabInstance: {fileID: 773834880}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1825113116
 GameObject:
   m_ObjectHideFlags: 0
@@ -7799,6 +8464,12 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1312448}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &1863711053 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+    type: 3}
+  m_PrefabInstance: {fileID: 1312448}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1871229384
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7844,7 +8515,7 @@ PrefabInstance:
     - target: {fileID: 2863848475787073641, guid: ceba5eb1d50934849bcaafc8bdb93daa,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.5495814
+      value: 0.722
       objectReference: {fileID: 0}
     - target: {fileID: 2863848475787073641, guid: ceba5eb1d50934849bcaafc8bdb93daa,
         type: 3}
@@ -8859,7 +9530,7 @@ PrefabInstance:
     - target: {fileID: 2863848475787073641, guid: ceba5eb1d50934849bcaafc8bdb93daa,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.5495814
+      value: 0.722
       objectReference: {fileID: 0}
     - target: {fileID: 2863848475787073641, guid: ceba5eb1d50934849bcaafc8bdb93daa,
         type: 3}
@@ -8908,7 +9579,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 71671166}
     m_Modifications:
     - target: {fileID: 166777569440315956, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -8958,7 +9629,22 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.01111111
+      objectReference: {fileID: 0}
+    - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.01111111
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
@@ -8968,7 +9654,7 @@ PrefabInstance:
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: -0.4833333
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}

--- a/WorldWrap/Assets/Scenes/SampleScene.unity
+++ b/WorldWrap/Assets/Scenes/SampleScene.unity
@@ -261,7 +261,7 @@ GameObject:
   - component: {fileID: 38465960}
   - component: {fileID: 38465959}
   - component: {fileID: 38465958}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -373,7 +373,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 64921085}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -410,7 +410,7 @@ GameObject:
   - component: {fileID: 91103854}
   - component: {fileID: 91103853}
   - component: {fileID: 91103852}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -520,7 +520,7 @@ GameObject:
   - component: {fileID: 94897361}
   - component: {fileID: 94897360}
   - component: {fileID: 94897359}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -749,7 +749,7 @@ GameObject:
   - component: {fileID: 118404506}
   - component: {fileID: 118404505}
   - component: {fileID: 118404504}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -865,7 +865,7 @@ GameObject:
   - component: {fileID: 209312216}
   - component: {fileID: 209312215}
   - component: {fileID: 209312214}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -975,7 +975,7 @@ GameObject:
   - component: {fileID: 212001945}
   - component: {fileID: 212001944}
   - component: {fileID: 212001943}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1081,7 +1081,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 236558027}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1118,7 +1118,7 @@ GameObject:
   - component: {fileID: 290594917}
   - component: {fileID: 290594916}
   - component: {fileID: 290594915}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1228,7 +1228,7 @@ GameObject:
   - component: {fileID: 297434120}
   - component: {fileID: 297434119}
   - component: {fileID: 297434118}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1338,7 +1338,7 @@ GameObject:
   - component: {fileID: 302715637}
   - component: {fileID: 302715636}
   - component: {fileID: 302715635}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1562,7 +1562,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 340960628}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (11)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1601,7 +1601,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 369934228}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (19)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1638,7 +1638,7 @@ GameObject:
   - component: {fileID: 384653560}
   - component: {fileID: 384653559}
   - component: {fileID: 384653558}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1863,7 +1863,7 @@ GameObject:
   - component: {fileID: 415450177}
   - component: {fileID: 415450176}
   - component: {fileID: 415450175}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2059,7 +2059,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 433647521}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2096,7 +2096,7 @@ GameObject:
   - component: {fileID: 451348201}
   - component: {fileID: 451348200}
   - component: {fileID: 451348199}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2202,7 +2202,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 460132692}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (14)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2239,7 +2239,7 @@ GameObject:
   - component: {fileID: 467097336}
   - component: {fileID: 467097335}
   - component: {fileID: 467097334}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2349,7 +2349,7 @@ GameObject:
   - component: {fileID: 479018155}
   - component: {fileID: 479018154}
   - component: {fileID: 479018153}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2574,7 +2574,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 524996674}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (18)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2836,7 +2836,7 @@ GameObject:
   - component: {fileID: 654252474}
   - component: {fileID: 654252473}
   - component: {fileID: 654252472}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3116,7 +3116,7 @@ GameObject:
   - component: {fileID: 729178441}
   - component: {fileID: 729178440}
   - component: {fileID: 729178439}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3226,7 +3226,7 @@ GameObject:
   - component: {fileID: 735345962}
   - component: {fileID: 735345961}
   - component: {fileID: 735345960}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3336,7 +3336,7 @@ GameObject:
   - component: {fileID: 765034758}
   - component: {fileID: 765034757}
   - component: {fileID: 765034756}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3565,7 +3565,7 @@ GameObject:
   - component: {fileID: 820851467}
   - component: {fileID: 820851466}
   - component: {fileID: 820851465}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3843,7 +3843,7 @@ GameObject:
   - component: {fileID: 937172307}
   - component: {fileID: 937172306}
   - component: {fileID: 937172305}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4072,7 +4072,7 @@ GameObject:
   - component: {fileID: 970519672}
   - component: {fileID: 970519671}
   - component: {fileID: 970519670}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4182,7 +4182,7 @@ GameObject:
   - component: {fileID: 981543909}
   - component: {fileID: 981543908}
   - component: {fileID: 981543907}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4288,7 +4288,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 985651815}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (20)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4321,7 +4321,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 998956810}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (16)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4354,7 +4354,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1017071410}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlocks
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4409,7 +4409,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1030520144}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4446,7 +4446,7 @@ GameObject:
   - component: {fileID: 1041967997}
   - component: {fileID: 1041967996}
   - component: {fileID: 1041967995}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4552,7 +4552,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1057809962}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (8)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4585,7 +4585,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1087276451}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (4)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4622,7 +4622,7 @@ GameObject:
   - component: {fileID: 1104024991}
   - component: {fileID: 1104024990}
   - component: {fileID: 1104024989}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4732,7 +4732,7 @@ GameObject:
   - component: {fileID: 1111586587}
   - component: {fileID: 1111586586}
   - component: {fileID: 1111586585}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4842,7 +4842,7 @@ GameObject:
   - component: {fileID: 1186163617}
   - component: {fileID: 1186163616}
   - component: {fileID: 1186163615}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4952,7 +4952,7 @@ GameObject:
   - component: {fileID: 1192313904}
   - component: {fileID: 1192313903}
   - component: {fileID: 1192313902}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5159,7 +5159,7 @@ GameObject:
   - component: {fileID: 1197213170}
   - component: {fileID: 1197213169}
   - component: {fileID: 1197213168}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5269,7 +5269,7 @@ GameObject:
   - component: {fileID: 1217603283}
   - component: {fileID: 1217603282}
   - component: {fileID: 1217603281}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5412,6 +5412,7 @@ MonoBehaviour:
   - {fileID: 1224477082}
   - {fileID: 1769589972}
   player: {fileID: 691913570}
+  wrapLayer: 5
 --- !u!4 &1244485131
 Transform:
   m_ObjectHideFlags: 0
@@ -5440,7 +5441,7 @@ GameObject:
   - component: {fileID: 1245591343}
   - component: {fileID: 1245591342}
   - component: {fileID: 1245591341}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5550,7 +5551,7 @@ GameObject:
   - component: {fileID: 1267225824}
   - component: {fileID: 1267225823}
   - component: {fileID: 1267225822}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5660,7 +5661,7 @@ GameObject:
   - component: {fileID: 1300238313}
   - component: {fileID: 1300238312}
   - component: {fileID: 1300238311}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5766,7 +5767,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1312486234}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (5)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5918,7 +5919,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1351721546}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (15)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5951,7 +5952,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1424712083}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (23)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5988,7 +5989,7 @@ GameObject:
   - component: {fileID: 1455868764}
   - component: {fileID: 1455868763}
   - component: {fileID: 1455868762}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6094,7 +6095,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1482822804}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (12)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6131,7 +6132,7 @@ GameObject:
   - component: {fileID: 1538079356}
   - component: {fileID: 1538079355}
   - component: {fileID: 1538079354}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6243,7 +6244,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1561045581}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (7)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6280,7 +6281,7 @@ GameObject:
   - component: {fileID: 1587326858}
   - component: {fileID: 1587326857}
   - component: {fileID: 1587326856}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6390,7 +6391,7 @@ GameObject:
   - component: {fileID: 1597626486}
   - component: {fileID: 1597626485}
   - component: {fileID: 1597626484}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6496,7 +6497,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1600446501}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (9)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6533,7 +6534,7 @@ GameObject:
   - component: {fileID: 1635940225}
   - component: {fileID: 1635940224}
   - component: {fileID: 1635940223}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6643,7 +6644,7 @@ GameObject:
   - component: {fileID: 1683494127}
   - component: {fileID: 1683494126}
   - component: {fileID: 1683494125}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6753,7 +6754,7 @@ GameObject:
   - component: {fileID: 1697869758}
   - component: {fileID: 1697869757}
   - component: {fileID: 1697869756}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6859,7 +6860,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1709895810}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (6)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6896,7 +6897,7 @@ GameObject:
   - component: {fileID: 1751677661}
   - component: {fileID: 1751677660}
   - component: {fileID: 1751677659}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7012,7 +7013,7 @@ GameObject:
   - component: {fileID: 1825113120}
   - component: {fileID: 1825113119}
   - component: {fileID: 1825113118}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7118,7 +7119,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1860861124}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (22)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7247,7 +7248,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1881942269}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7280,7 +7281,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1897060124}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (17)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7317,7 +7318,7 @@ GameObject:
   - component: {fileID: 1913379045}
   - component: {fileID: 1913379044}
   - component: {fileID: 1913379043}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7427,7 +7428,7 @@ GameObject:
   - component: {fileID: 1922173894}
   - component: {fileID: 1922173893}
   - component: {fileID: 1922173892}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7537,7 +7538,7 @@ GameObject:
   - component: {fileID: 1967457177}
   - component: {fileID: 1967457176}
   - component: {fileID: 1967457175}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7655,7 +7656,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1981120421}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (13)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7692,7 +7693,7 @@ GameObject:
   - component: {fileID: 1992558649}
   - component: {fileID: 1992558648}
   - component: {fileID: 1992558647}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7808,7 +7809,7 @@ GameObject:
   - component: {fileID: 2044709772}
   - component: {fileID: 2044709771}
   - component: {fileID: 2044709770}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7918,7 +7919,7 @@ GameObject:
   - component: {fileID: 2053999789}
   - component: {fileID: 2053999788}
   - component: {fileID: 2053999787}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8028,7 +8029,7 @@ GameObject:
   - component: {fileID: 2093626331}
   - component: {fileID: 2093626330}
   - component: {fileID: 2093626329}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8134,7 +8135,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2104520023}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: WrapBlock (21)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8253,6 +8254,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: RedBlock
+      objectReference: {fileID: 0}
+    - target: {fileID: 2577308036908700981, guid: 8825810ddf0f5419aac6ea7be02043f4,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4136743966250944051, guid: 8825810ddf0f5419aac6ea7be02043f4,
         type: 3}

--- a/WorldWrap/Assets/Scripts/BlockTrigger.cs
+++ b/WorldWrap/Assets/Scripts/BlockTrigger.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class BlockTrigger : TriggerBehavior
 {
+    private List<GameObject> objectsInsideBox = new List<GameObject>();
 
     private void OnTriggerEnter(Collider other)
     {
@@ -11,6 +12,7 @@ public class BlockTrigger : TriggerBehavior
         {
             wrapManager.LogBlockEntry(gameObject);
         }
+        objectsInsideBox.Add(other.gameObject);
     }
 
     private void OnTriggerExit(Collider other)
@@ -19,5 +21,6 @@ public class BlockTrigger : TriggerBehavior
         {
             wrapManager.LogBlockExit(gameObject);
         }
+        objectsInsideBox.Remove(other.gameObject);
     }
 }

--- a/WorldWrap/Assets/Scripts/BlockTrigger.cs
+++ b/WorldWrap/Assets/Scripts/BlockTrigger.cs
@@ -12,7 +12,10 @@ public class BlockTrigger : TriggerBehavior
         {
             wrapManager.LogBlockEntry(gameObject);
         }
-        objectsInsideBox.Add(other.gameObject);
+        if (other.gameObject.layer != wrapManager.GetWrapLayer())
+        {
+            objectsInsideBox.Add(other.gameObject);
+        }
     }
 
     private void OnTriggerExit(Collider other)
@@ -22,5 +25,10 @@ public class BlockTrigger : TriggerBehavior
             wrapManager.LogBlockExit(gameObject);
         }
         objectsInsideBox.Remove(other.gameObject);
+    }
+
+    public List<GameObject> getResidents()
+    {
+        return objectsInsideBox;
     }
 }

--- a/WorldWrap/Assets/Scripts/BlockTrigger.cs
+++ b/WorldWrap/Assets/Scripts/BlockTrigger.cs
@@ -4,7 +4,8 @@ using UnityEngine;
 
 public class BlockTrigger : TriggerBehavior
 {
-    private List<GameObject> objectsInsideBox = new List<GameObject>();
+    // Residents refers to the gameobjects inside the block
+    private List<GameObject> residents = new List<GameObject>();
 
     private void OnTriggerEnter(Collider other)
     {
@@ -14,7 +15,7 @@ public class BlockTrigger : TriggerBehavior
         }
         if (other.gameObject.layer != wrapManager.GetWrapLayer())
         {
-            objectsInsideBox.Add(other.gameObject);
+            residents.Add(other.gameObject);
         }
     }
 
@@ -24,11 +25,11 @@ public class BlockTrigger : TriggerBehavior
         {
             wrapManager.LogBlockExit(gameObject);
         }
-        objectsInsideBox.Remove(other.gameObject);
+        residents.Remove(other.gameObject);
     }
 
     public List<GameObject> getResidents()
     {
-        return objectsInsideBox;
+        return residents;
     }
 }

--- a/WorldWrap/Assets/Scripts/BoundsTrigger.cs
+++ b/WorldWrap/Assets/Scripts/BoundsTrigger.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BoundsTrigger : TriggerBehavior
+{
+    float lowerXBound;
+    float lowerZBound;
+    float upperXBound;
+    float upperZBound;
+
+    protected override void Start()
+    {
+        base.Start();
+        lowerXBound = wrapManager.transform.position.x - gameObject.transform.lossyScale.x / 2;
+        upperXBound = wrapManager.transform.position.x + gameObject.transform.lossyScale.x / 2;
+        lowerZBound = wrapManager.transform.position.z - gameObject.transform.lossyScale.z / 2;
+        upperZBound = wrapManager.transform.position.z + gameObject.transform.lossyScale.z / 2;
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        Vector3 otherTransform = other.gameObject.transform.position;
+        float otherX = otherTransform.x;
+        float otherZ = otherTransform.z;
+        if (otherX <= lowerXBound)
+        {
+            otherTransform.x = upperXBound;
+        }
+        else if (otherX >= upperXBound)
+        {
+            otherTransform.x = lowerXBound;
+        }
+        if (otherZ <= lowerZBound)
+        {
+            otherTransform.z = upperZBound;
+        }
+        else if (otherZ >= upperZBound)
+        {
+            otherTransform.z = lowerZBound;
+        }
+        other.gameObject.transform.position = otherTransform;
+    }
+}

--- a/WorldWrap/Assets/Scripts/BoundsTrigger.cs.meta
+++ b/WorldWrap/Assets/Scripts/BoundsTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 649b90a10a146468bbf5e8d90c736e74
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WorldWrap/Assets/Scripts/FlyForward.cs
+++ b/WorldWrap/Assets/Scripts/FlyForward.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FlyForward : MonoBehaviour
+{
+    [SerializeField] private float speed;
+    // Start is called before the first frame update
+    void Start()
+    {
+        Rigidbody objectRigidBody = gameObject.GetComponent<Rigidbody>();
+        objectRigidBody.velocity = transform.TransformDirection(Vector3.forward) * speed;
+    }
+
+}

--- a/WorldWrap/Assets/Scripts/FlyForward.cs.meta
+++ b/WorldWrap/Assets/Scripts/FlyForward.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9f5f8ffe9a6845b5b5247ffbe35b63f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WorldWrap/Assets/Scripts/TriggerBehavior.cs
+++ b/WorldWrap/Assets/Scripts/TriggerBehavior.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 public class TriggerBehavior : MonoBehaviour
 {
     protected WrapManager wrapManager;
+    protected int wrapLayer;
 
     protected void Start()
     {
@@ -18,6 +19,7 @@ public class TriggerBehavior : MonoBehaviour
             Exception missingManagerException = new Exception("To use WarpTriggers, WarpManager object must exist and be called WarpManager");
             Debug.LogException(missingManagerException);
         }
+        wrapLayer = wrapManager.GetWrapLayer();
     }
 
 }

--- a/WorldWrap/Assets/Scripts/TriggerBehavior.cs
+++ b/WorldWrap/Assets/Scripts/TriggerBehavior.cs
@@ -8,7 +8,7 @@ public class TriggerBehavior : MonoBehaviour
     protected WrapManager wrapManager;
     protected int wrapLayer;
 
-    protected void Start()
+    protected virtual void Start()
     {
         try
         {

--- a/WorldWrap/Assets/Scripts/WrapManager.cs
+++ b/WorldWrap/Assets/Scripts/WrapManager.cs
@@ -154,7 +154,6 @@ public class WrapManager : MonoBehaviour
         {
             TranslateRight(newMatrix);
         }
-        //player.transform.Translate(-1*translationVector, Space.World);
         return newMatrix;
     }
 
@@ -165,12 +164,7 @@ public class WrapManager : MonoBehaviour
         {
             for(int column = 0; column < oldPositions.GetLength(1); column++)
             {
-                // TODO: For every BlockTrigger, move the objects NOT in the wrap layer that don't have parents
-                // Step 1: Get movement vector (newMatrix position - old matrix podition)
                 movementVector = oldPositions[row,column] - newMatrix[row,column].transform.position;
-                // Step 2: Get BlockTrigger inside list
-                // Step 3: Move everything from list NOT in wrap layer AND without parent via movement vector
-                // NOTE: Player will be in this list. Remove previous command to move them alone
                 TranslateObjects(newMatrix[row,column], movementVector);
                 newMatrix[row,column].transform.position = oldPositions[row,column];
             }

--- a/WorldWrap/Assets/Scripts/WrapManager.cs
+++ b/WorldWrap/Assets/Scripts/WrapManager.cs
@@ -154,17 +154,37 @@ public class WrapManager : MonoBehaviour
         {
             TranslateRight(newMatrix);
         }
-        player.transform.Translate(-1*translationVector, Space.World);
+        //player.transform.Translate(-1*translationVector, Space.World);
         return newMatrix;
     }
 
     private void TranslateBlocks(Vector3[,] oldPositions, GameObject[,] newMatrix)
     {
+        Vector3 movementVector;
         for(int row = 0; row < oldPositions.GetLength(0); row++)
         {
             for(int column = 0; column < oldPositions.GetLength(1); column++)
             {
+                // TODO: For every BlockTrigger, move the objects NOT in the wrap layer that don't have parents
+                // Step 1: Get movement vector (newMatrix position - old matrix podition)
+                movementVector = oldPositions[row,column] - newMatrix[row,column].transform.position;
+                // Step 2: Get BlockTrigger inside list
+                // Step 3: Move everything from list NOT in wrap layer AND without parent via movement vector
+                // NOTE: Player will be in this list. Remove previous command to move them alone
+                TranslateObjects(newMatrix[row,column], movementVector);
                 newMatrix[row,column].transform.position = oldPositions[row,column];
+            }
+        }
+    }
+
+    private void TranslateObjects(GameObject block, Vector3 movementVector)
+    {
+        BlockTrigger triggerScript = block.GetComponentInChildren<BlockTrigger>();
+        foreach(GameObject resident in triggerScript.getResidents())
+        {
+            if (resident.transform.parent == null)
+            {
+                resident.transform.Translate(movementVector, Space.World);
             }
         }
     }

--- a/WorldWrap/Assets/Scripts/WrapManager.cs
+++ b/WorldWrap/Assets/Scripts/WrapManager.cs
@@ -8,6 +8,7 @@ public class WrapManager : MonoBehaviour
 {
     [SerializeField] private GameObject[] blocks;
     [SerializeField] private GameObject player;
+    [SerializeField] private int wrapLayer;
     private GameObject[,] blockMatrix;
     private GameObject initialTrigger;
     private GameObject currentTrigger;
@@ -243,5 +244,10 @@ public class WrapManager : MonoBehaviour
                 newMatrix[row + 1, column] = blockMatrix[row, column];
             }
         }
+    }
+
+    public int GetWrapLayer()
+    {
+        return wrapLayer;
     }
 }

--- a/WorldWrap/ProjectSettings/TagManager.asset
+++ b/WorldWrap/ProjectSettings/TagManager.asset
@@ -12,7 +12,7 @@ TagManager:
   - 
   - Water
   - UI
-  - 
+  - WorldWrapObjects
   - 
   - 
   - 


### PR DESCRIPTION
FIX: Allows objects to remain in their same relative positions on the map during world wraps ie it is "safe" to leave an object while wrapping the world. Non-player objects can now also wrap around the world, exemplified by three "ducks".