### PR TITLE
FIX: Fixes issue where players may wrap after exiting the sameWrapTrigger they entered

### DIFF
--- a/WorldWrap/Assets/Scenes/DodgeballGame.unity
+++ b/WorldWrap/Assets/Scenes/DodgeballGame.unity
@@ -3895,7 +3895,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 691913570}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -10.85, y: 0.973, z: 0.39999962}
+  m_LocalPosition: {x: -10, y: 0.973, z: 0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/WorldWrap/Assets/Scripts/BlockTrigger.cs
+++ b/WorldWrap/Assets/Scripts/BlockTrigger.cs
@@ -32,4 +32,9 @@ public class BlockTrigger : TriggerBehavior
     {
         return residents;
     }
+
+    public void removeResident(GameObject oldResident)
+    {
+        residents.Remove(oldResident);
+    }
 }

--- a/WorldWrap/Assets/Scripts/Dodgeball/DodgeballEnemy.cs
+++ b/WorldWrap/Assets/Scripts/Dodgeball/DodgeballEnemy.cs
@@ -267,6 +267,6 @@ public class DodgeballEnemy : DodgeballActor
         pickupRadius = 3;
         searchForBallTime = 7.0f;
         minThrowRadius = 8;
-        minThrowRadius = 20;
+        maxThrowRadius = 20;
     }
 }

--- a/WorldWrap/Assets/Scripts/WrapManager.cs
+++ b/WorldWrap/Assets/Scripts/WrapManager.cs
@@ -169,6 +169,7 @@ public class WrapManager : MonoBehaviour
             blockMatrix = newMatrix;
             initialTrigger = null;
         }
+        initialTrigger = null;
     }
 
     public void LogBlockEntry(GameObject enterBlock)
@@ -235,14 +236,31 @@ public class WrapManager : MonoBehaviour
     private void TranslateObjects(GameObject block, Vector3 movementVector, HashSet<int> objectAlreadyMoved)
     {
         BlockTrigger triggerScript = block.GetComponentInChildren<BlockTrigger>();
-        foreach(GameObject resident in triggerScript.getResidents())
+        List<GameObject> residentsOfBlock = triggerScript.getResidents();
+        GameObject[] oldResidents = new GameObject[residentsOfBlock.Count];
+        int oldResidentCounter = 0;
+        foreach(GameObject resident in residentsOfBlock)
         {
+            if (resident == null)
+            {
+                oldResidents[oldResidentCounter] = resident;
+                oldResidentCounter ++;
+                continue;
+            }
             int key = resident.GetInstanceID();
             if (resident.transform.parent == null && !objectAlreadyMoved.Contains(key))
             {
                 objectAlreadyMoved.Add(key);
                 MoveObject(resident, movementVector);
             }
+        }
+        foreach(GameObject oldResident in oldResidents)
+        {
+            if (oldResident == null)
+            {
+                break;
+            }
+            triggerScript.removeResident(oldResident);
         }
     }
 


### PR DESCRIPTION
FIX: Fixes issue that caused players to sometimes wrap after exiting the sameWrapTrigger they entered. This would occur when the player was initiated inside a wrap trigger A, stepped into a new trigger B, stepped into the new trigger C from B, then went back to B from C and exited B.